### PR TITLE
Add article: WSL2 + Docker Desktop 環境で compinit の _docker エラーの原因と対策

### DIFF
--- a/articles/9f2a4d7c1b3e9a.md
+++ b/articles/9f2a4d7c1b3e9a.md
@@ -1,0 +1,140 @@
+---
+title: "WSL2 + Docker Desktop環境で compinit の _docker エラーが出る原因と対策"
+emoji: "🐳"
+type: "tech"
+topics:
+  - "wsl2"
+  - "ubuntu"
+  - "zsh"
+  - "dockerdesktop"
+  - "shell"
+published: false
+---
+
+Windows + WSL2（Ubuntu 24.04.1）で zsh を使っていると、起動時や `source ~/.zshrc` 実行時に次のメッセージが出ることがあります。
+
+```text
+compinit:527: no such file or directory: /usr/share/zsh/vendor-completions/_docker
+```
+
+この記事は **「WSL 側に Docker を入れていない / Docker Desktop の WSL 連携を使っている」** 前提で、GitHub issue ベースに原因と対策を整理します。
+
+## 結論（先に短く）
+
+- 主因は `~/.zshrc` のタイポではなく、**Docker Desktop が作った `_docker` シンボリックリンクの残骸**です。
+- リンク先は `/mnt/wsl/docker-desktop/...` 配下で、Docker Desktop 停止時や連携不整合時に消えることがあります。
+- その結果、`compinit` が存在しない補完ファイルを読みに行って警告/エラー表示になります。
+
+関連 issue:
+
+- Docker Desktop 側: [docker/for-win#14056](https://github.com/docker/for-win/issues/14056)
+- その前段の不具合: [docker/for-win#13910](https://github.com/docker/for-win/issues/13910)
+- 同様症状報告（WSL 側未インストールでも発生）: [ohmyzsh/ohmyzsh#12154](https://github.com/ohmyzsh/ohmyzsh/issues/12154)
+
+---
+
+## 何が起きているか
+
+`compinit` は zsh 補完の初期化処理です。`fpath` 上の補完ファイル（`_docker` など）を読み込みます。
+
+Docker Desktop の WSL 連携では、WSL 側に次のようなリンクができることがあります。
+
+```text
+/usr/share/zsh/vendor-completions/_docker
+ -> /mnt/wsl/docker-desktop/cli-tools/usr/share/zsh/vendor-completions/_docker
+```
+
+このリンク先は Docker Desktop の状態に依存するため、
+
+- Docker Desktop を止めた
+- Desktop のアップデート直後
+- WSL 連携の切り替え/不整合
+
+といったタイミングでリンク切れになることがあります。
+リンク切れのまま zsh が起動すると、今回の `compinit` メッセージが出ます。
+
+---
+
+## まず確認すること
+
+### 1) リンク切れか確認
+
+```bash
+ls -l /usr/share/zsh/vendor-completions/_docker
+readlink -f /usr/share/zsh/vendor-completions/_docker
+```
+
+`No such file or directory` になる、または `/mnt/wsl/docker-desktop/...` が解決できなければリンク切れです。
+
+### 2) Docker Desktop 連携状況を確認
+
+```bash
+docker version
+```
+
+WSL 側で `Server: Docker Desktop` が見えるか確認します。
+見えない場合は Docker Desktop 側の WSL Integration 設定を見直します。
+
+---
+
+## 対策
+
+## A. まず壊れたリンクを削除（最優先）
+
+```bash
+sudo rm -f /usr/share/zsh/vendor-completions/_docker
+rm -f ~/.zcompdump*
+exec zsh
+```
+
+これで `compinit` のエラー表示は止まることが多いです。
+
+## B. Docker 補完を使いたい場合
+
+Docker Desktop が起動していて `docker` コマンドが使える状態で、ユーザー領域に補完を生成します。
+
+```bash
+mkdir -p ~/.zfunc
+docker completion zsh > ~/.zfunc/_docker
+```
+
+`~/.zshrc` で `fpath` に `~/.zfunc` を先頭追加してから `compinit` します。
+
+```zsh
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit
+compinit
+```
+
+これなら `/usr/share/zsh/vendor-completions/_docker` に依存しません。
+
+## C. Docker 補完が不要なら無効化
+
+Oh My Zsh の `plugins=(...)` に `docker` / `docker-compose` が入っているなら外し、再起動します。
+
+```bash
+rm -f ~/.zcompdump*
+exec zsh
+```
+
+## D. Docker Desktop を更新
+
+`docker/for-win#14056` では、コメントで「4.32.0 前後で改善した」という報告があります。
+古い Desktop を使っているなら更新も有効です（ただし環境差はあるので A/B 併用推奨）。
+
+---
+
+## どこまで深刻？
+
+多くの場合は「zsh 自体は使えるが Docker 補完が壊れる」症状です。
+ただし毎回ノイズが出ると本当のエラーを見落としやすいので、壊れたリンクは早めに掃除するのが無難です。
+
+---
+
+## まとめ
+
+- 今回のケース（WSL2 + Docker Desktop）では、原因は **`_docker` 補完リンクの残骸**であることが多い
+- まず `sudo rm -f /usr/share/zsh/vendor-completions/_docker` でリンクを消し、`~/.zcompdump` を再生成
+- 補完が必要なら `docker completion zsh > ~/.zfunc/_docker` でユーザー側に固定配置すると安定しやすい
+
+同じエラーでも「WSL 側に Docker を入れていないのに出る」ことは普通にあり、Docker Desktop の WSL 連携由来の副作用として理解すると対処しやすいです。


### PR DESCRIPTION
### Motivation
- Document a common `compinit: no such file or directory: /usr/share/zsh/vendor-completions/_docker` error seen on Windows + WSL2 (Ubuntu) when using Docker Desktop WSL integration. 
- Explain that the root cause is often a broken symbolic link created by Docker Desktop pointing into `/mnt/wsl/docker-desktop/...` and that the link can break when Desktop is stopped or integration changes. 
- Provide clear, actionable checks and multiple remediation options so users can quickly remove noise or restore stable Docker zsh completions. 

### Description
- Add a new technical article at `articles/9f2a4d7c1b3e9a.md` that explains the issue, links to relevant GitHub issues, and outlines diagnosis commands like `ls -l /usr/share/zsh/vendor-completions/_docker` and `readlink -f ...`. 
- Include step-by-step mitigations: remove the broken link with `sudo rm -f /usr/share/zsh/vendor-completions/_docker` and `rm -f ~/.zcompdump*`, generate a user-local completion via `docker completion zsh > ~/.zfunc/_docker` and update `fpath`, and disable Docker plugins in Oh My Zsh if completions are not needed. 
- Recommend updating Docker Desktop as a longer-term fix and summarize the expected severity and trade-offs. 

### Testing
- No automated tests were run for this content addition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e8e9d188832bb8abcd84e36ce1b2)